### PR TITLE
Added logic to check existence of temp directory

### DIFF
--- a/src/main/java/com/fizzed/jne/JNE.java
+++ b/src/main/java/com/fizzed/jne/JNE.java
@@ -665,7 +665,7 @@ public class JNE {
      */
     static private File getOrCreateTempDirectory(boolean deleteOnExit) throws ExtractException {
         // return the single instance if already created
-        if (_tempDir != null) {
+        if ((_tempDir != null) && _tempDir.exists()) {
             return _tempDir;
         }
         


### PR DESCRIPTION
This is the change I made to ensure that temp files deleted on an EC2 instance can be restored by the snapshot micro service.  The JNE utility class wasn't checking for the existence of the temp directory held by the _tempDir member once it had been assigned. 